### PR TITLE
Create HttpClient object when is used

### DIFF
--- a/CrossCutting/DopplerSapService/DopplerSapService.cs
+++ b/CrossCutting/DopplerSapService/DopplerSapService.cs
@@ -17,8 +17,9 @@ namespace CrossCutting.DopplerSapService
     {
         private readonly DopplerSapServiceSettings _dopplerSapServiceSettings;
         private readonly JsonSerializerSettings _serializationSettings;
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<DopplerSapService> _logger;
+        private readonly HttpClientPoliciesSettings _httpClientPoliciesSettings;
 
         public DopplerSapService(
             IHttpClientFactory httpClientFactory,
@@ -27,8 +28,9 @@ namespace CrossCutting.DopplerSapService
             ILogger<DopplerSapService> logger)
         {
             _dopplerSapServiceSettings = dopplerSapServiceSettings.CurrentValue;
-            _httpClient = httpClientFactory.CreateClient(httpClientPoliciesSettings.ClientName);
+            _httpClientFactory = httpClientFactory;
             _logger = logger;
+            _httpClientPoliciesSettings = httpClientPoliciesSettings;
             _serializationSettings = new JsonSerializerSettings
             {
                 Formatting = Formatting.Indented,
@@ -62,7 +64,8 @@ namespace CrossCutting.DopplerSapService
             try
             {
                 _logger.LogInformation("Sending request to Doppler SAP Api.");
-                httpResponse = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
+                var client = _httpClientFactory.CreateClient(_httpClientPoliciesSettings.ClientName);
+                httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -91,7 +94,8 @@ namespace CrossCutting.DopplerSapService
             try
             {
                 _logger.LogInformation("Sending request to Doppler SAP Api.");
-                httpResponse = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
+                var client = _httpClientFactory.CreateClient(_httpClientPoliciesSettings.ClientName);
+                httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
+++ b/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
@@ -16,8 +16,9 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
     {
         private readonly DopplerCurrencyServiceSettings _dopplerCurrencySettings;
         private readonly TimeZoneJobConfigurations _jobConfig;
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;
         private readonly ILogger<DopplerCurrencyService> _logger;
+        private readonly HttpClientPoliciesSettings _httpClientPoliciesSettings;
 
         public DopplerCurrencyService(
             IHttpClientFactory httpClientFactory,
@@ -28,8 +29,9 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
         {
             _dopplerCurrencySettings = dopplerCurrencySettings;
             _jobConfig = jobConfig;
-            _httpClient = httpClientFactory.CreateClient(httpClientPoliciesSettings.ClientName);
             _logger = logger;
+            _httpClientFactory = httpClientFactory;
+            _httpClientPoliciesSettings = httpClientPoliciesSettings;
         }
 
         public async Task<IList<CurrencyResponse>> GetCurrencyByCode()
@@ -55,8 +57,9 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
 
                     };
                     
-                    _logger.LogInformation("Sending request to Doppler Currency Api."); 
-                    var httpResponse = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false);
+                    _logger.LogInformation("Sending request to Doppler Currency Api.");
+                    var client = _httpClientFactory.CreateClient(_httpClientPoliciesSettings.ClientName);
+                    var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
 
                     if (!httpResponse.IsSuccessStatusCode)
                         continue;

--- a/DopplerJobsServer/Properties/launchSettings.json
+++ b/DopplerJobsServer/Properties/launchSettings.json
@@ -17,7 +17,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "Server": {
+    "Doppler.Job.Server": {
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "hangfire",


### PR DESCRIPTION
# Background
We use IHttpClientFactory, the default handler lifetime is two minutes, see [link](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#httpclient-and-lifetime-management)
I moved `HttpClientFactory.CreateClient()` when is used

can you review it?