### PR TITLE
Remove unnecessary timezone converter

### DIFF
--- a/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
+++ b/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CrossCutting;
 using CrossCutting.DopplerSapService.Entities;
 using Doppler.Currency.Job.Settings;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using TimeZoneConverter;
 
 namespace Doppler.Currency.Job.DopplerCurrencyService
 {
@@ -36,10 +34,7 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
 
         public async Task<IList<CurrencyResponse>> GetCurrencyByCode()
         {
-            var tz = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? _jobConfig.TimeZoneJobs 
-                : TZConvert.WindowsToIana(_jobConfig.TimeZoneJobs);
-
-            var cstZone = TimeZoneInfo.FindSystemTimeZoneById(tz);
+            var cstZone = TimeZoneInfo.FindSystemTimeZoneById(_jobConfig.TimeZoneJobs);
             var cstTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, cstZone);
             
             var returnList = new List<CurrencyResponse>();

--- a/DopplerJobTest/CreateSutCurrencyServiceTests.cs
+++ b/DopplerJobTest/CreateSutCurrencyServiceTests.cs
@@ -24,7 +24,7 @@ namespace Doppler.Jobs.Test
                 loggerCurrencyService ?? Mock.Of<ILogger<DopplerCurrencyService>>(),
                 timeZoneJobConfigurations ?? new TimeZoneJobConfigurations
                 {
-                    TimeZoneJobs = "Argentina Standard Time"
+                    TimeZoneJobs = TimeZoneHelper.GetTimeZoneByOperativeSystem("Argentina Standard Time") 
                 });
         }
     }


### PR DESCRIPTION
# Background
The App run in Windows and Linux(Docker) correctly, but exis a problem with Timezone for example:
Argentina timezone string:
Linux -> America/Argentina/Buenos_Aires
Windows -> Argentina Standard Time
The timezone in setting in appsettings.json and convert in Startup.cs