### PR TITLE
[DSL-177] retry get currency for holidays

### DIFF
--- a/DopplerCurrencyJob/DopplerCurrencyJob.cs
+++ b/DopplerCurrencyJob/DopplerCurrencyJob.cs
@@ -32,7 +32,7 @@ namespace Doppler.Currency.Job
             var currencyDto = await _dopplerCurrencyService.GetCurrencyByCode();
 
             if (!currencyDto.Any())
-                return "Non-existent Currency for this date, please check if it's a holiday.";
+                return "Non-existent currencies for this date, please check for errors";
 
             _logger.LogInformation("Sending currency data to Doppler SAP system.");
             await _dopplerSapService.SendCurrency(currencyDto);

--- a/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
+++ b/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
@@ -42,38 +42,49 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
         public async Task<IList<CurrencyResponse>> GetCurrencyByCode()
         {
             var cstZone = TimeZoneInfo.FindSystemTimeZoneById(_jobConfig.TimeZoneJobs);
-            var cstTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, cstZone);
-            
             var returnList = new List<CurrencyResponse>();
             
             foreach (var currencyCode in _dopplerCurrencySettings.CurrencyCodeList)
             {
-                try { 
-                    var uri = new Uri(_dopplerCurrencySettings.Url + $"{currencyCode}/{cstTime.Year}-{cstTime.Month}-{cstTime.Day}");
-                    
-                    _logger.LogInformation("Building http request with url {uri}", uri); 
-                    var httpRequest = new HttpRequestMessage 
-                    {
-                        RequestUri = uri, 
-                        Method = new HttpMethod("GET")
+                try
+                {
+                    var cstTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, cstZone);
+                    var retryCount = 0;
 
-                    };
-                    
-                    _logger.LogInformation("Sending request to Doppler Currency Api.");
-                    var client = _httpClientFactory.CreateClient(_httpClientPoliciesSettings.ClientName);
-                    var httpResponse = await client.SendAsync(httpRequest).ConfigureAwait(false);
+                    var httpResponse = await GetCurrencyValue(currencyCode, cstTime);
+                    var jsonResult = await httpResponse.Content.ReadAsStringAsync();
+                    var isHoliday = jsonResult.Contains("Holiday Error") || jsonResult.Contains("Html Error Mxn currency");
+
+                    if (!isHoliday && !httpResponse.IsSuccessStatusCode )
+                    {
+                        _logger.LogError(httpResponse.ReasonPhrase,"Error getting currency for {currencyCode}.", currencyCode);
+                        continue;
+                    }
+                    else if (isHoliday)
+                    {
+                        while (retryCount < _dopplerCurrencySettings.HolidayRetryCountLimit)
+                        {
+                            cstTime = DateTime.UtcNow.DayOfWeek == DayOfWeek.Monday ? cstTime.AddDays(-3) : cstTime.AddDays(-1);
+                            httpResponse = await GetCurrencyValue(currencyCode, cstTime);
+                            if (httpResponse.IsSuccessStatusCode)
+                                break;
+                            retryCount += 1;
+                        }
+                    }
 
                     if (!httpResponse.IsSuccessStatusCode)
+                    {
+                        _logger.LogError(httpResponse.ReasonPhrase,"Error getting currency for {currencyCode} after trying for the last 5 business days", currencyCode);
                         continue;
+                    }
 
-                    var json = await httpResponse.Content.ReadAsStringAsync();
-                    var result = JsonConvert.DeserializeObject<CurrencyResponse>(json);
+                    var result = JsonConvert.DeserializeObject<CurrencyResponse>(jsonResult);
 
                     returnList.Add(result);
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError(e,"Error GetCurrency for {currencyCode}.", currencyCode);
+                    _logger.LogError(e,"Unexpected error getting currency for {currencyCode}.", currencyCode);
                     throw;
                 }
             }
@@ -115,6 +126,23 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
                 _logger.LogCritical(e, "Error sending SQL sentence to database server.");
                 throw;
             }
+        }
+
+        private async Task<HttpResponseMessage> GetCurrencyValue(string currencyCode , DateTime cstTime )
+        {
+            var uri = new Uri(_dopplerCurrencySettings.Url + $"{currencyCode}/{cstTime.Year}-{cstTime.Month}-{cstTime.Day}");
+
+            _logger.LogInformation("Building http request with url {uri}", uri);
+            var httpRequest = new HttpRequestMessage
+            {
+                RequestUri = uri,
+                Method = new HttpMethod("GET")
+
+            };
+
+            _logger.LogInformation("Sending request to Doppler Currency Api.");
+            var client = _httpClientFactory.CreateClient();
+            return await client.SendAsync(httpRequest).ConfigureAwait(false);
         }
     }
 }

--- a/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
+++ b/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
@@ -67,7 +67,10 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
                             cstTime = DateTime.UtcNow.DayOfWeek == DayOfWeek.Monday ? cstTime.AddDays(-3) : cstTime.AddDays(-1);
                             httpResponse = await GetCurrencyValue(currencyCode, cstTime);
                             if (httpResponse.IsSuccessStatusCode)
+                            {
+                                jsonResult = await httpResponse.Content.ReadAsStringAsync();
                                 break;
+                            }  
                             retryCount += 1;
                         }
                     }

--- a/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
+++ b/DopplerCurrencyJob/DopplerCurrencyService/DopplerCurrencyService.cs
@@ -53,11 +53,11 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
 
                     var httpResponse = await GetCurrencyValue(currencyCode, cstTime);
                     var jsonResult = await httpResponse.Content.ReadAsStringAsync();
-                    var isHoliday = jsonResult.Contains("Holiday Error") || jsonResult.Contains("Html Error Mxn currency");
+                    var isHoliday = jsonResult.Contains("No USD for this date") || jsonResult.Contains("Html Error Mxn currency");
 
                     if (!isHoliday && !httpResponse.IsSuccessStatusCode )
                     {
-                        _logger.LogError(httpResponse.ReasonPhrase,"Error getting currency for {currencyCode}.", currencyCode);
+                        _logger.LogError("{ReasonPhrase}. Error getting currency for {currencyCode}.", httpResponse.ReasonPhrase, currencyCode);
                         continue;
                     }
                     else if (isHoliday)
@@ -74,7 +74,7 @@ namespace Doppler.Currency.Job.DopplerCurrencyService
 
                     if (!httpResponse.IsSuccessStatusCode)
                     {
-                        _logger.LogError(httpResponse.ReasonPhrase,"Error getting currency for {currencyCode} after trying for the last 5 business days", currencyCode);
+                        _logger.LogError("{ReasonPhrase}. Error getting currency for {currencyCode} after trying for the last 5 business days", httpResponse.ReasonPhrase, currencyCode);
                         continue;
                     }
 

--- a/DopplerCurrencyJob/Settings/DopplerCurrencyServiceSettings.cs
+++ b/DopplerCurrencyJob/Settings/DopplerCurrencyServiceSettings.cs
@@ -7,5 +7,6 @@ namespace Doppler.Currency.Job.Settings
         public string Url { get; set; }
         public List<string> CurrencyCodeList { get; set; }
         public string InsertCurrencyQuery { get; set; }
+        public int HolidayRetryCountLimit { get; set; }
     }
 }

--- a/DopplerJobTest/DopplerCurrencyServiceTests.cs
+++ b/DopplerJobTest/DopplerCurrencyServiceTests.cs
@@ -169,7 +169,7 @@ namespace Doppler.Jobs.Test
                 .ReturnsAsync(new HttpResponseMessage
                 {
                     StatusCode = HttpStatusCode.BadRequest,
-                    Content = new StringContent("{\"success\":false,\"errors\":{\"Holiday Error\":[\"Error getting date is holiday, please check Bna page.\"]}}")
+                    Content = new StringContent("{\"success\":false,\"errors\":{\"No USD for this date\":[\"There are no pending USD currency for that date.\"]}}")
                 });
 
             _httpClientFactoryMock.Setup(_ => _.CreateClient(It.IsAny<string>()))

--- a/DopplerJobsServer/appsettings.json
+++ b/DopplerJobsServer/appsettings.json
@@ -52,7 +52,8 @@
     "DopplerCurrencyServiceSettings": {
         "Url": "http://172.24.16.82:10550/currency/",
         "CurrencyCodeList": [ "ARS", "MXN" ],
-        "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]"
+        "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
+        "HolidayRetryCountLimit": 5
     },
   "DopplerSapConfiguration": {
     "CurrencyEndpoint": "http://localhost:65100/Billing/SetCurrencyRate",


### PR DESCRIPTION
We need to send the currency to SAP every day, even if it is a Holiday. Because of this, we need to retry the request for getting the currency to previous days.
With these changes, I'm trying to retry the request for a maximum of five previous business days. The first successful request will break the loop and return that value.

Any suggestion is more than welcome!!
