### PR TITLE
Modify cron expression for the billing job

### DIFF
--- a/DopplerJobsServer/appsettings.json
+++ b/DopplerJobsServer/appsettings.json
@@ -23,7 +23,7 @@
   "AllowedHosts": "*",
   "Jobs": {
     "DopplerBillingJobSettings": {
-      "IntervalCronExpression": "0 18 28 * *",
+      "IntervalCronExpression": "0 9 1 * *",
       "Identifier": "Doppler_Billing_Job",
       "StoredProcedures": [
         "exec [dbo].[SAP_CM_GB_BISIDE_ARG];",


### PR DESCRIPTION
We need the billing jobs to be executed the first of each month, not before.
This is already applied in production.