### PR TITLE
DAT-103-Update urls for the currency job

### DIFF
--- a/DopplerJobsServer/appsettings.QA.json
+++ b/DopplerJobsServer/appsettings.QA.json
@@ -1,6 +1,6 @@
 {
   "DopplerCurrencyServiceSettings": {
-    "Url": "https://apisqa.fromdoppler.net/currency/currency/",
+    "Url": "https://apisqa.fromdoppler.net/currency/conversion/",
     "CurrencyCodeList": [ "ARS" ],
     "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
     "HolidayRetryCountLimit": 5

--- a/DopplerJobsServer/appsettings.int.json
+++ b/DopplerJobsServer/appsettings.int.json
@@ -1,6 +1,6 @@
 {
   "DopplerCurrencyServiceSettings": {
-    "Url": "https://apisint.fromdoppler.net/currency/currency/",
+    "Url": "https://apisint.fromdoppler.net/currency/conversion/",
     "CurrencyCodeList": [ "ARS" ],
     "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
     "HolidayRetryCountLimit": 5

--- a/DopplerJobsServer/appsettings.json
+++ b/DopplerJobsServer/appsettings.json
@@ -50,7 +50,7 @@
     }
   },
   "DopplerCurrencyServiceSettings": {
-    "Url": "https://apis.fromdoppler.com/currency/currency/",
+    "Url": "https://localhost:44353/",
     "CurrencyCodeList": [ "ARS" ],
     "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
     "HolidayRetryCountLimit": 5

--- a/DopplerJobsServer/appsettings.prod.json
+++ b/DopplerJobsServer/appsettings.prod.json
@@ -1,6 +1,8 @@
 {
   "DopplerCurrencyServiceSettings": {
-    "Url": "",
-    "CurrencyCodeList": [ "ARS" ]
+    "Url": "https://apis.fromdoppler.com/currency/conversion/",
+    "CurrencyCodeList": [ "ARS" ],
+    "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
+    "HolidayRetryCountLimit": 5
   }
 }


### PR DESCRIPTION
Updated the configs of the INT, QA and PROD to use the correct url for currency api

Changes:

**- INT:**  
           "Url": "https://apisint.fromdoppler.net/currency/conversion/"

**- QA:**  
           "Url": "https://apisqa.fromdoppler.net/currency/conversion/"

**- PROD:** 
             "Url": "https://apis.fromdoppler.com/currency/conversion/"

Also in the PROD config added:
"InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
 "HolidayRetryCountLimit": 5
