### PR TITLE
[DAT-73] Update settings for production environment

### DIFF
--- a/DopplerJobsServer/Program.cs
+++ b/DopplerJobsServer/Program.cs
@@ -38,6 +38,9 @@ namespace Doppler.Jobs.Server
                     // the content `Trace`. See:
                     // https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#key-per-file-configuration-provider
                     configurationBuilder.AddKeyPerFile("/run/secrets", true);
+                    
+                    // Configuration for Docker Windows containers.
+                    configurationBuilder.AddKeyPerFile("C:\\ProgramData\\Docker\\secrets", true);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/DopplerJobsServer/Program.cs
+++ b/DopplerJobsServer/Program.cs
@@ -30,7 +30,7 @@ namespace Doppler.Jobs.Server
                     configurationBuilder.AddJsonFile("/run/secrets/appsettings.Secret.json", true);
 
                     // Configuration for Docker Windows containers.
-                    configurationBuilder.AddJsonFile("/ProgramData/docker/secrets/appsettings.Secret.json", true);
+                    configurationBuilder.AddJsonFile("C:\\ProgramData\\Docker\\secrets\\appsettings.Secret.json", true);
 
                     // It is to override configuration using a different file
                     // for each configuration entry. For example, you can create

--- a/DopplerJobsServer/Startup.cs
+++ b/DopplerJobsServer/Startup.cs
@@ -93,7 +93,7 @@ namespace Doppler.Jobs.Server
 
             app.UseHangfireDashboard("/hangfire", new DashboardOptions
             {
-                PrefixPath = !env.IsDevelopment() ? "/jobs" : null,
+                PrefixPath = Configuration["PrefixHangfireDashboard"],
                 Authorization = new[] {new HangfireAuthorizationFilter()},
                 IsReadOnlyFunc = context => !env.IsDevelopment()
             });

--- a/DopplerJobsServer/Startup.cs
+++ b/DopplerJobsServer/Startup.cs
@@ -91,18 +91,16 @@ namespace Doppler.Jobs.Server
 
             app.UseStaticFiles();
 
-            if (env.IsDevelopment())
+            app.UseHangfireDashboard("/hangfire", new DashboardOptions
             {
-                app.UseHangfireDashboard("/hangfire", new DashboardOptions
-                {
-                    PrefixPath = !env.IsDevelopment() ? "/jobs" : null,
-                    Authorization = new[] {new HangfireAuthorizationFilter()}
-                });
-            }
+                PrefixPath = !env.IsDevelopment() ? "/jobs" : null,
+                Authorization = new[] {new HangfireAuthorizationFilter()},
+                IsReadOnlyFunc = context => !env.IsDevelopment()
+            });
 
             app.UseHangfireServer(new BackgroundJobServerOptions
             {
-                WorkerCount = 5
+                WorkerCount = 1
             });
         }
 

--- a/DopplerJobsServer/appsettings.QA.json
+++ b/DopplerJobsServer/appsettings.QA.json
@@ -18,5 +18,6 @@
       "IntervalCronExpression": "0 0 1 12 *",
       "Identifier": "Doppler_Currency_Job"
     }
-  }
+  },
+  "PrefixHangfireDashboard": "/jobs"
 }

--- a/DopplerJobsServer/appsettings.int.json
+++ b/DopplerJobsServer/appsettings.int.json
@@ -18,5 +18,6 @@
       "IntervalCronExpression": "0 0 1 12 *",
       "Identifier": "Doppler_Currency_Job"
     }
-  }
+  },
+  "PrefixHangfireDashboard": "/jobs"
 }

--- a/DopplerJobsServer/appsettings.prod.json
+++ b/DopplerJobsServer/appsettings.prod.json
@@ -1,8 +1,31 @@
 {
   "DopplerCurrencyServiceSettings": {
-    "Url": "https://apis.fromdoppler.com/currency/conversion/",
-    "CurrencyCodeList": [ "ARS" ],
+    "Url": "http://currency/conversion/",
+    "CurrencyCodeList": [ "ARS", "MXN" ],
     "InsertCurrencyQuery": "[dbo].[InsertNewCurrencyRate]",
     "HolidayRetryCountLimit": 5
+  },
+  "DopplerSapConfiguration": {
+    "CurrencyEndpoint": "http://172.24.16.82:65100/Billing/SetCurrencyRate",
+    "BillingEndpoint": "http://172.24.16.82:65100/Billing/CreateBillingRequest"
+  },
+  "Jobs": {
+    "DopplerBillingJobSettings": {
+      "IntervalCronExpression": "0 9 1 * *",
+      "Identifier": "Doppler_Billing_Job",
+      "StoredProcedures": [
+        "exec [dbo].[SAP_CM_GB_BISIDE_ARG];",
+        "exec [dbo].[SAP_CM_GB_BISIDE_USD];",
+        "exec [dbo].[SAP_CM_GB_DD_ARG];",
+        "exec [dbo].[SAP_CM_GB_DD_USD];",
+        "exec [dbo].[SAP_GB_BISIDE_ARG];",
+        "exec [dbo].[SAP_GB_BISIDE_USD];",
+        "exec [dbo].[SAP_GB_DD_ARG]"
+      ]
+    },
+    "DopplerCurrencyJob": {
+      "IntervalCronExpression": "0 18 * * mon-fri",
+      "Identifier": "Doppler_Currency_Job"
+    }
   }
 }

--- a/DopplerJobsServer/appsettings.prod.json
+++ b/DopplerJobsServer/appsettings.prod.json
@@ -27,5 +27,6 @@
       "IntervalCronExpression": "0 18 * * mon-fri",
       "Identifier": "Doppler_Currency_Job"
     }
-  }
+  },
+  "PrefixHangfireDashboard":  "/jobs"
 }


### PR DESCRIPTION
# Background
- Fix configs for the production environment
- Add path in Program.cs to locate secret keys in a server
- Only read Hangfire dashboard in production
- Decrement worker, we need one worker

Task: https://makingsense.atlassian.net/browse/DAT-73