### PR TITLE
DAT-104-update-logic-holiday

### DIFF
--- a/CrossCutting/DopplerSapService/Entities/CurrencyResponse.cs
+++ b/CrossCutting/DopplerSapService/Entities/CurrencyResponse.cs
@@ -10,5 +10,6 @@ namespace CrossCutting.DopplerSapService.Entities
         public decimal? BuyValue { get; set; }
         public string CurrencyName { get; set; }
         public string CurrencyCode { get; set; }
+        public bool CotizationAvailable { get; set; }
     }
 }


### PR DESCRIPTION
Update logic to check the holiday in the Currency Job.

**Changes:**
 
Now check if the current date has prices using a new property: CotizationAvailable instead of check by message.

Before:

```csharp
   var isHoliday = jsonResult.Contains("No USD for this date") || jsonResult.Contains("Html Error Mxn currency");
   
   if (!isHoliday && !httpResponse.IsSuccessStatusCode )
   {
          ...
    }
   else
   {
        ....
   }
```

Now:

```csharp
if (result.CotizationAvailable)
{
       ....
}
else
{
   ....
}
```

Also updated the UTs.


