### PR TITLE
Show build button in hangfire dashboard

### DIFF
--- a/DopplerJobsServer/Startup.cs
+++ b/DopplerJobsServer/Startup.cs
@@ -95,8 +95,7 @@ namespace Doppler.Jobs.Server
             app.UseHangfireDashboard("/hangfire", new DashboardOptions
             {
                 PrefixPath = Configuration["PrefixHangfireDashboard"],
-                Authorization = new[] {new HangfireAuthorizationFilter()},
-                IsReadOnlyFunc = context => !env.IsDevelopment()
+                Authorization = new[] {new HangfireAuthorizationFilter()}
             });
 
             app.UseHangfireServer(new BackgroundJobServerOptions


### PR DESCRIPTION
# Background
We need to run the Doppler Billing job manually, so when executing manually it job this change should be removed